### PR TITLE
Removed twitter share count

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ npm install sharing-metrics --save
 ```
 
 ### API Providers
-These are the available providers. By default only facebook and twitter share counts are enabled.
+These are the available providers.
 
 - facebook: `https://api.facebook.com/method/links.getStats?format=json&urls=`
-- twitter: `http://urls.api.twitter.com/1/urls/count.json?url=`
 - pinterest: `http://api.pinterest.com/v1/urls/count.json?url=`
 
 ### Documentation
@@ -37,7 +36,7 @@ shares.getCount(url, function(error, tally) {
 
 **Sample output**
 ```
-{ total: 1, twitter: 0, pinterest: 1 }
+{ total: 1, pinterest: 1 }
 ```
 
 ### Contributions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharing-metrics",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Asynchronous social sharing metrics",
   "main": "src/shares.js",
   "scripts": {
@@ -20,8 +20,7 @@
   "author": "Newsela",
   "license": "MIT",
   "dependencies": {
-    "async": "^1.4.2",
-    "request": "^2.60.0"
+    "async": "^1.4.2"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/src/parser.js
+++ b/src/parser.js
@@ -4,18 +4,13 @@ var parseFacebookShares = function(body) {
   return JSON.parse(body)[0].share_count;
 };
 
-var parseTwitterShares = function(body) {
-  return JSON.parse(body).count;
-};
-
 var parsePinterestShares = function(body) {
   return JSON.parse(body.slice(13, -1)).count;
 };
 
 var RESPONSE_PARSERS = {
   'facebook': parseFacebookShares,
-  'twitter': parseTwitterShares,
-  'pinterest': parsePinterestShares,
+  'pinterest': parsePinterestShares
 };
 
 module.exports = function(provider) {

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -7,14 +7,8 @@ describe('parser', function() {
 
   it('should correctly parse the facebook count', function() {
     var facebookParser = parser('facebook');
-    var mockedResponseBody = '[{"url":"https:\/\/newsela.com\/articles\/turtle-navigation\/id\/7010\/","normalized_url":"https:\/\/www.newsela.com\/articles\/turtle-navigation\/id\/7010\/","share_count":9000,"like_count":0,"comment_count":0,"total_count":0,"click_count":0,"comments_fbid":null,"commentsbox_count":0}]';
-    assert.strictEqual(facebookParser(mockedResponseBody), 9000);
-  });
-
-  it('should correctly parse the twitter count', function() {
-    var twitterParser = parser('twitter');
-    var mockedResponseBody = '{"count":9000,"url":"https:\/\/newsela.com\/articles\/turtle-navigation\/id\/7010\/"}';
-    assert.strictEqual(twitterParser(mockedResponseBody), 9000);
+    var mockedResponseBody = '[{"url":"http:\/\/newsela.com","normalized_url":"http:\/\/www.newsela.com\/","share_count":1498,"like_count":1268,"comment_count":932,"total_count":3698,"click_count":0,"comments_fbid":"1385084535036639","commentsbox_count":0}]';
+    assert.strictEqual(facebookParser(mockedResponseBody), 1498);
   });
 
   it('should correctly parse the pinterest count', function() {

--- a/test/test-shares.js
+++ b/test/test-shares.js
@@ -5,9 +5,9 @@ var shares = require('../src/shares');
 
 describe('shares', function() {
 
-  describe('.isObject()', function() {
-    var providers = shares.getProviders();
+  var providers = shares.THE_API_ENDPOINTS;
 
+  describe('.isObject()', function() {
     it('should expose the API providers for public use', function() {
       assert.isObject(providers);
     });
@@ -16,29 +16,19 @@ describe('shares', function() {
       assert.property(providers, 'facebook');
     });
 
-    it('should contain the twitter share provider', function() {
-      assert.property(providers, 'twitter');
-    });
-
     it('should contain the pinterest share provider', function() {
       assert.property(providers, 'pinterest');
     });
   });
 
-
   describe('.enable()', function() {
-    var providers = shares.getProviders();
-
     it('should enable the given provider', function() {
       shares.enable('pinterest');
       assert.isTrue(providers.pinterest.enabled);
     });
   });
 
-
   describe('.disable()', function() {
-    var providers = shares.getProviders();
-
     it('should disbale the given provider', function() {
       shares.disable('facebook');
       assert.isFalse(providers.facebook.enabled);


### PR DESCRIPTION
Because of Twitter's deprecation of its share count feature, twitter will no longer be supported after this PR. Upgrading this module is mandatory as it is currently broken. 